### PR TITLE
feat: improve contrast based on wcag contrast checker

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,6 +23,7 @@ const Home: NextPage = () => {
         alignItems="center"
         justifyContent="center"
         flexDirection="column"
+        bg="gray.400"
       >
         <Image
           borderRadius="full"
@@ -37,10 +38,12 @@ const Home: NextPage = () => {
           minW="sm"
           maxW="sm"
           borderWidth="1px"
+          borderColor="gray.500"
           borderRadius="lg"
           overflow="hidden"
           p="8"
           flexDirection="column"
+          bg="white"
         >
           <Textarea
             size="sm"
@@ -68,11 +71,11 @@ const Home: NextPage = () => {
           </Button>
 
           <Button
-            colorScheme="gray"
+            backgroundColor="gray.300"
             leftIcon={<FaTwitter />}
             mt="10px"
             as={'a'}
-            href="https://twitter.com/intent/user?screen_name=sseraphini" 
+            href="https://twitter.com/intent/user?screen_name=sseraphini"
             target="_blank"
           >
             Follow


### PR DESCRIPTION
- tweet button fails but its on brand
- moved from 3 (text + 2 buttons) to 4 elements (text + 2 buttons + form box) as AAA visible


### before

![Screen Shot 2022-01-14 at 11 42 22 am](https://user-images.githubusercontent.com/829902/149420681-ca8e7c7f-b4dc-4322-b0fe-5299cc27e006.png)

### after

![Screen Shot 2022-01-14 at 11 42 01 am](https://user-images.githubusercontent.com/829902/149420706-feba11d5-06ea-49cd-8706-b140d66238d1.png)

