### PR TITLE
feat: add infinite scroll function to timeline page

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-icons": "^4.3.1",
+    "react-infinite-scroll-component": "^6.1.0",
     "styled-components": "^5.3.3"
   },
   "devDependencies": {

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,11 +1,24 @@
+import InfiniteScroll from 'react-infinite-scroll-component';
 import { Flex, Text } from '@chakra-ui/react';
 import TweetInfo from './TweetInfo';
 import { TweetData } from '../types/Tweet';
+import { useState } from 'react';
 
 interface Props {
-  tweets?: TweetData[];
+  initialTweets?: TweetData[];
+  initialNextToken?: string;
 }
-export const Timeline = ({ tweets }: Props) => {
+export const Timeline = ({ initialTweets, initialNextToken }: Props) => {
+  const [tweets, setTweets] = useState(initialTweets);
+  const [nextToken, setNextToken] = useState(initialNextToken);
+
+  const fetchData = async () => {
+    const response = await fetch(`/api/latest_tweets?nextToken=${nextToken}`);
+    const json = await response.json();
+    setNextToken(json.nextToken);
+    setTweets([...(tweets || []), ...json.tweets]);
+  };
+
   if (!tweets) {
     return null;
   }
@@ -21,9 +34,16 @@ export const Timeline = ({ tweets }: Props) => {
       <Text fontWeight="medium" fontSize={24}>
         Latest tweets
       </Text>
-      {tweets?.map((tweet) => (
-        <TweetInfo key={tweet.id} tweet={tweet} />
-      ))}
+      <InfiniteScroll
+        dataLength={tweets?.length || 0}
+        next={fetchData}
+        hasMore={true}
+        loader={<Text>Loading...</Text>}
+      >
+        {tweets?.map((tweet) => (
+          <TweetInfo key={tweet.id} tweet={tweet} />
+        ))}
+      </InfiniteScroll>
     </Flex>
   );
 };

--- a/src/pages/api/latest_tweets.ts
+++ b/src/pages/api/latest_tweets.ts
@@ -9,6 +9,9 @@ interface TwitterResponse {
   includes: {
     users: TwitterResponseUserInfo[];
   };
+  meta: {
+    next_token: string;
+  };
 }
 
 const BASE_URL = 'https://api.twitter.com/2';
@@ -29,9 +32,14 @@ export default async function handler(
     });
   }
 
-  const url =
+  let url =
     `${BASE_URL}/${RECENT_TWEETS_URL}?query=${QUERY}&tweet.fields=${TWEET_FIELDS}` +
     `&user.fields=${USER_FIELDS}&expansions=${EXPANSIONS}&max_results=${MAX_RESULTS}`;
+
+  if (req.query.nextToken) {
+    url += `&next_token=${req.query.nextToken}`;
+  }
+
   const response = await fetch(url, {
     headers: {
       Authorization: `Bearer ${process.env.TWITTER_BEARER_TOKEN}`,
@@ -49,5 +57,8 @@ export default async function handler(
     };
   });
 
-  return res.status(200).json(tweets);
+  return res.status(200).json({
+    tweets,
+    nextToken: tweetsData.meta.next_token,
+  });
 }

--- a/src/pages/timeline.tsx
+++ b/src/pages/timeline.tsx
@@ -6,11 +6,14 @@ import { TweetData } from '../types/Tweet';
 import { Timeline } from '../components/Timeline';
 
 interface Props {
-  tweets?: TweetData[];
+  data?: {
+    tweets?: TweetData[];
+    nextToken?: string;
+  };
   error?: boolean;
 }
 
-const TimelinePage: NextPage<Props> = ({ tweets, error }: Props) => {
+const TimelinePage: NextPage<Props> = ({ data, error }: Props) => {
   if (error) {
     return (
       <Flex
@@ -32,7 +35,10 @@ const TimelinePage: NextPage<Props> = ({ tweets, error }: Props) => {
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
-      <Timeline tweets={tweets} />
+      <Timeline
+        initialTweets={data?.tweets}
+        initialNextToken={data?.nextToken}
+      />
     </div>
   );
 };
@@ -55,11 +61,14 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
       },
     };
   }
-  const data = await response.json();
 
+  const data = await response.json();
   return {
     props: {
-      tweets: data,
+      data: {
+        tweets: data?.tweets,
+        nextToken: data?.nextToken,
+      },
     },
   };
 };


### PR DESCRIPTION
This PR adds infinite scroll to timeline page (issue #20).

As is defined on the twitter api docs **meta.next_token** is a value that encodes the next 'page' of results that can be requested, via the next_token request parameter.