### PR TITLE
feat: add google chrome extension link as an action button

### DIFF
--- a/apps/web/src/components/ActionButtons.tsx
+++ b/apps/web/src/components/ActionButtons.tsx
@@ -1,6 +1,6 @@
 import { Button, Stack } from '@chakra-ui/react';
 import { FaTwitter, FaPatreon } from 'react-icons/fa';
-import { SiSubstack } from 'react-icons/si';
+import { SiGooglechrome, SiSubstack } from 'react-icons/si';
 
 export const ActionButtons = () => {
   return (
@@ -49,6 +49,20 @@ export const ActionButtons = () => {
           size="sm"
         >
           Articles
+        </Button>
+
+        <Button
+          colorScheme="red"
+          leftIcon={<SiGooglechrome />}
+          mt={{ base: '0', md: '10px' }}
+          width="100%"
+          as={'a'}
+          border="none"
+          href="https://chrome.google.com/webstore/detail/ccsseraphini/jbdolkjfpfgpbdeeebkhnmfnbkplgalm"
+          target="_blank"
+          size="sm"
+        >
+          Google Chrome extension
         </Button>
       </Stack>
     </>

--- a/apps/web/src/components/ActionButtons.tsx
+++ b/apps/web/src/components/ActionButtons.tsx
@@ -62,7 +62,7 @@ export const ActionButtons = () => {
           target="_blank"
           size="sm"
         >
-          Google Chrome extension
+          Install cc @sseraphini
         </Button>
       </Stack>
     </>


### PR DESCRIPTION
# Summary
This PR adds google chrome extension link as an action button to solve #119 . Here is a screenshot:

![Screenshot from 2022-01-28 10-10-05](https://user-images.githubusercontent.com/89654793/151552512-a6b4fbd2-4b7d-4730-97fa-7b4b501e34ec.png)

❗❗❗ I'm ok with changing button color scheme if needed.

## Checklist
- [ X ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
