### PR TITLE
feat: added calculation of user score

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -51,9 +51,5 @@
     "jest-fetch-mock": "3.0.3",
     "typescript": "4.6.2",
     "whatwg-fetch": "3.6.2"
-  },
-  "jest": {
-    "automock": false,
-    "resetMocks": false
   }
 }

--- a/apps/web/src/components/TwitterLogin.tsx
+++ b/apps/web/src/components/TwitterLogin.tsx
@@ -3,13 +3,9 @@ import { signIn, signOut, useSession } from 'next-auth/react';
 
 export const TwitterLogin = ({}) => {
   const { data: session } = useSession();
+
   type ButtonProps = {
-    login: {
-      onClick: () => Promise<undefined>;
-      colorScheme: string;
-      text: string;
-    };
-    logout: {
+    [index: string]: {
       onClick: () => Promise<undefined>;
       colorScheme: string;
       text: string;

--- a/apps/web/src/pages/api/auth/[...nextauth].ts
+++ b/apps/web/src/pages/api/auth/[...nextauth].ts
@@ -1,9 +1,20 @@
 import NextAuth from 'next-auth';
 import TwitterProvider from 'next-auth/providers/twitter';
+import { AccountProfile } from 'types/Score';
+import { userScore } from '../userScore';
 
 export default NextAuth({
   callbacks: {
-    session({ session }) {
+    async signIn({ account, profile }: AccountProfile) {
+      if (account.provider === 'twitter') {
+        const score = await userScore({ account, profile });
+        console.log(score);
+      }
+
+      return true;
+    },
+    session({ session, token }) {
+      session.id = token.sub;
       return session;
     },
   },
@@ -12,6 +23,20 @@ export default NextAuth({
       clientId: process.env.TWITTER_CLIENT_ID || '',
       clientSecret: process.env.TWITTER_CLIENT_SECRET || '',
       version: '2.0',
+      userinfo: {
+        params: {
+          'user.fields': ['id'],
+          'tweet.fields': ['text'],
+        },
+      },
+      profile(props) {
+        const { data } = props;
+        return {
+          id: data.id,
+          name: data.name,
+          image: data.profile_image_url,
+        };
+      },
     }),
   ],
 });

--- a/apps/web/src/pages/api/userScore.ts
+++ b/apps/web/src/pages/api/userScore.ts
@@ -1,0 +1,54 @@
+import { AccountProfile } from 'types/Score';
+
+export const userScore = async ({
+  account: { providerAccountId, access_token },
+  profile: {
+    data: { username },
+  },
+}: AccountProfile) => {
+  const BASE_URL = 'https://api.twitter.com/2';
+  const USER_TIMELINE_URL =
+    `${BASE_URL}/users/${providerAccountId}/tweets?` +
+    'tweet.fields=public_metrics,in_reply_to_user_id&max_results=100';
+
+  const { data }: Response = await fetch(USER_TIMELINE_URL, {
+    headers: {
+      Authorization: `Bearer ${access_token}`,
+    },
+  }).then(async (data) => data.json());
+
+  if (!!data) {
+    const currentUser = username;
+    interface PublicMetrics {
+      public_metrics: {
+        retweet_count: number;
+        reply_count: number;
+        like_count: number;
+        quote_count: number;
+      };
+    }
+
+    const score = data
+      .filter((tweet: { text: string; in_reply_to_user_id: string }) => {
+        const { text, in_reply_to_user_id } = tweet;
+
+        const isMentioned = text.match(/cc(:?\s*)@sseraphini/gi);
+        const isReplied = text.match(
+          new RegExp(`@${currentUser} @sseraphini`, 'gi'),
+        );
+        const isReplyingToUser = in_reply_to_user_id === '2313873457';
+
+        return isMentioned || isReplied || isReplyingToUser;
+      })
+      .reduce((accumulator: number, current: PublicMetrics): number => {
+        const { retweet_count, reply_count, like_count, quote_count } =
+          current.public_metrics;
+
+        return (
+          accumulator + retweet_count + reply_count + like_count + quote_count
+        );
+      }, 0);
+
+    return score;
+  }
+};

--- a/apps/web/src/types/Score.ts
+++ b/apps/web/src/types/Score.ts
@@ -1,0 +1,6 @@
+import { Account, Profile } from 'next-auth';
+
+export type AccountProfile = {
+  account: Account;
+  profile: Profile & Record<string, any>;
+};

--- a/apps/web/test/pages/__tests__/Home.test.tsx
+++ b/apps/web/test/pages/__tests__/Home.test.tsx
@@ -1,6 +1,12 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import Home from '../../../src/pages';
 
+beforeAll(() => {
+  fetchMock.doMock();
+});
+
+afterEach(() => fetchMock.resetMocks());
+
 beforeEach(() => {
   render(<Home />);
 });


### PR DESCRIPTION
That PR is a part of #270.
After that, I think that the follow tasks are done:

- [x] twitter oauth
- [x] user login using twitter
- [x] compute the score of tweets like, rt, replies

### Important: 
- It's just a function with the base calculation of the user score.
- It isn't showing the score in anywhere besides the console.
- It's just the twitter API request for authenticated user's tweets


### Feel free to continue that task if you want to create the page to users claim discord access.