### PR TITLE
add max height to tweet image preview

### DIFF
--- a/apps/web/src/components/tweet/Tweet.tsx
+++ b/apps/web/src/components/tweet/Tweet.tsx
@@ -132,6 +132,7 @@ const Tweet = ({ tweet }: TweetInfoProps) => {
                       key={chunk.index}
                       src={chunk.value}
                       alt={tweet.userInfo.name}
+                      maxH={350}
                     />
                   );
                 }


### PR DESCRIPTION
# Summary
Issue #277 
Just added a simple max height attribute to tweet image preview.


![Captura de tela de 2022-03-23 15-27-54](https://user-images.githubusercontent.com/32819600/159771243-7603b78e-23a0-4d63-9dcc-c4f98952087d.png)
![Captura de tela de 2022-03-23 15-28-48](https://user-images.githubusercontent.com/32819600/159771263-2002f4e5-1dfd-4b66-994d-4b183b92f7f8.png)


