### PR TITLE
fix(web): home button href

### DIFF
--- a/apps/web/src/components/score/Score.tsx
+++ b/apps/web/src/components/score/Score.tsx
@@ -16,7 +16,7 @@ export const Score = ({
         <ChakraNextLinkButton
           backgroundColor="green.200"
           as={'a'}
-          href={`/home`}
+          href={'/'}
           width={'49%'}
         >
           Home


### PR DESCRIPTION
#Description

When an error loading the score happens, the button to back to the home is going to the wrong page (`/home`)﻿.
This PR basically changes the href to `/`
