### PR TITLE
feat: flood the discord channel with latest tweets #319

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -4,3 +4,4 @@ TWITTER_CLIENT_ID=
 TWITTER_CLIENT_SECRET=
 TWITTER_PROFILE_ID=#2313873457
 TWITTER_PROFILE_USER=#sseraphini
+WEB_HOOK_DISCORD= #get this url creating a channel then create a webhook, copy the url and paste here

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -4,4 +4,4 @@ TWITTER_CLIENT_ID=
 TWITTER_CLIENT_SECRET=
 TWITTER_PROFILE_ID=#2313873457
 TWITTER_PROFILE_USER=#sseraphini
-WEB_HOOK_DISCORD= #get this url creating a channel then create a webhook, copy the url and paste here
+WEBHOOK_DISCORD= #get this url creating a channel then create a webhook, copy the url and paste here

--- a/apps/web/src/config.tsx
+++ b/apps/web/src/config.tsx
@@ -11,4 +11,5 @@ export const config = {
   DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET as string,
   DISCORD_BOT_TOKEN: process.env.DISCORD_BOT_TOKEN as string,
   GUILD_ID: process.env.GUILD_ID as string,
+  WEBHOOK_DISCORD: process.env.WEBHOOK_DISCORD as string,
 } as const;

--- a/apps/web/src/pages/api/discord/flood.ts
+++ b/apps/web/src/pages/api/discord/flood.ts
@@ -1,0 +1,56 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { TweetData } from 'types/Tweet';
+
+// Learn Discord Webhook: https://discord.com/developers/docs/resources/webhook#execute-webhook
+
+const floodDiscordChannelWithTweets = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+) => {
+  // TODO add auth method, only cron job can access this endpoint
+  // TODO handle with discord rate limit
+  // cron will trigger the API every 1 minute
+  // get the lastest tweets
+
+  const query = '-RT cc @sseraphini';
+
+  // TODO Dry this code, we have the same code: ccsseraphini/apps/web/src/pages/index.tsx
+  const httpProtocol = req.headers.host?.includes('localhost')
+    ? 'http'
+    : 'https';
+
+  const url = `${httpProtocol}://${req.headers.host}/api/tweets?query=${query}`;
+
+  const response = await fetch(url);
+
+  if (response.status !== 200)
+    res.status(500).send("I can't get the tweets, try again later");
+
+  const data = await response.json();
+
+  const WEB_HOOK = process.env.WEB_HOOK_DISCORD as string;
+
+  if (!WEB_HOOK) res.status(500).send('WEB_HOOK_DISCORD .env is not defined');
+
+  const promises = data.tweets.map((tweet: TweetData) => {
+    return fetch(WEB_HOOK, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+      body: JSON.stringify({
+        content: `https://twitter.com/${tweet.userInfo.username}/status/${tweet.id}`,
+      }),
+    });
+  });
+
+  try {
+    // TODO handle with discord rate limit
+    await Promise.all(promises);
+    res.status(204).send({ success: true });
+  } catch (error) {
+    res.status(500).send({ error });
+  }
+};
+
+export default floodDiscordChannelWithTweets;


### PR DESCRIPTION
Solve this https://github.com/sibelius/ccsseraphini/issues/22

Cronjob grabs every 1 minute all the latest tweets from `cc/api/tweets`  and use webhook from discord to send the tweets in the #tweets sibs discord channel.

__

Please @sibelius create an account for you here: https://console.cron-job.org/

Then create a job like img bellow, replacing the URL by:

```
https://sseraphini.cc/api/discord/flood
```

<img width="1263" alt="Screen Shot 2022-03-25 at 16 36 45" src="https://user-images.githubusercontent.com/380327/160197392-ce6c5597-fa21-4acb-a77a-b3d246fd97a9.png">



Add to vercel the `.env` WEBHOOK_DISCORD with that link you sent me in DM.

So, Everything should ok!


What is missing:

- [ ] tests
- [ ] auth method on cron job, I can help on it
- [ ] improve how not to repeat the tweets
- [ ] remove comments TODO inside of the code



