### PR TITLE
feat: create middleware to handle errors and validations

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -5,3 +5,5 @@ TWITTER_CLIENT_SECRET=
 TWITTER_PROFILE_ID=#2313873457
 TWITTER_PROFILE_USER=#sseraphini
 WEBHOOK_DISCORD= #get this url creating a channel then create a webhook, copy the url and paste here
+CRONJOB_HEADER_KEY=# add a key here, should be the same as in cronjob.org, sample: x-servicename-supersecret-key
+CRONJOB_HEADER_VALUE=# add a value here, should be same as in cronjob.org , sample: 1q2w3e4r5t6y7u8i9o0p

--- a/apps/web/src/config.tsx
+++ b/apps/web/src/config.tsx
@@ -12,4 +12,6 @@ export const config = {
   DISCORD_BOT_TOKEN: process.env.DISCORD_BOT_TOKEN as string,
   GUILD_ID: process.env.GUILD_ID as string,
   WEBHOOK_DISCORD: process.env.WEBHOOK_DISCORD as string,
+  CRONJOB_HEADER_KEY: process.env.CRONJOB_HEADER_KEY as string,
+  CRONJOB_HEADER_VALUE: process.env.CRONJOB_HEADER_VALUE as string,
 } as const;

--- a/apps/web/src/middlewares/error-handler.ts
+++ b/apps/web/src/middlewares/error-handler.ts
@@ -1,0 +1,15 @@
+import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
+
+// TODO create tests for this function
+const withErrorHandler =
+  (fn: NextApiHandler) => async (req: NextApiRequest, res: NextApiResponse) => {
+    try {
+      return await fn(req, res);
+    } catch (err: any) {
+      const statusCode = err.statusCode || 500;
+      const message = err.message || 'Oops, something went wrong!';
+      res.status(statusCode).json({ statusCode, message });
+    }
+  };
+
+export default withErrorHandler;

--- a/apps/web/src/middlewares/validations.ts
+++ b/apps/web/src/middlewares/validations.ts
@@ -1,0 +1,41 @@
+import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
+import { config } from '../config';
+
+// TODO create tests for this function
+const withValidation =
+  (fn: NextApiHandler) => async (req: NextApiRequest, res: NextApiResponse) => {
+    try {
+      // Adding new security layer, make hard to hackers using the browser for DDoS atack
+      if (req.method !== 'POST') res.status(405).send('method not allowed');
+
+      if (!config.CRONJOB_HEADER_KEY) {
+        res.status(500).json({ error: 'env CRONJOB_HEADER_KEY not set' });
+      }
+
+      if (!config.CRONJOB_HEADER_VALUE)
+        res.status(500).json({ error: 'env CRONJOB_HEADER_VALUE not set' });
+
+      if (!req.headers[config.CRONJOB_HEADER_KEY])
+        res
+          .status(400)
+          .send('CronjobOrg should provide secretkey in the header');
+
+      if (
+        req.headers[config.CRONJOB_HEADER_KEY] !== config.CRONJOB_HEADER_VALUE
+      ) {
+        res
+          .status(401)
+          .send(
+            'Ops! Wrong header value, check the env variable or cronjob.org account',
+          );
+      }
+
+      return await fn(req, res);
+    } catch (err: any) {
+      const statusCode = err.statusCode || 500;
+      const message = err.message || 'Oops, something went wrong!';
+      res.status(statusCode).json({ statusCode, message });
+    }
+  };
+
+export default withValidation;


### PR DESCRIPTION
Added middlewares (HOF) to handle with validations (cleaning code) and handle errors.


Add these .env and after create cronjob, add the key header: x-servicename-supersecret-key and value header: 1q2w3e4r5t6y7u8i9o0p

CRONJOB_HEADER_KEY=# add a key here, should be the same as in cronjob.org, sample: x-servicename-supersecret-key
CRONJOB_HEADER_VALUE=# add a value here, should be same as in cronjob.org , sample: 1q2w3e4r5t6y7u8i9o0p
