### PR TITLE
fix(TweetPublicMetrics): flex wrap to fix responsivity

### DIFF
--- a/apps/web/src/components/tweet/TweetPublicMetrics.tsx
+++ b/apps/web/src/components/tweet/TweetPublicMetrics.tsx
@@ -49,6 +49,7 @@ const TweetPublicMetrics = ({ tweet }: TweetInfoProps) => {
         borderColor="gray.300"
         alignItems="center"
         justifyContent="space-between"
+        flexWrap="wrap"
       >
         <Flex>
           <Button


### PR DESCRIPTION
## Description
Adding `flex-wrap: wrap;` to fix the responsivity on mobile devices.

## Screenshot
<img width="261" alt="Screen Shot 2022-04-01 at 22 43 02" src="https://user-images.githubusercontent.com/57234795/161360718-ecce2335-892f-455f-a40a-64e0ac628c9c.png">
(iPhone 13)

