### PR TITLE
Fix(web): Fixed GitHub button not clickable on mobile

### DIFF
--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -4,7 +4,7 @@ import { GetServerSideProps } from 'next';
 import { TweetData } from '../types/Tweet';
 import { Timeline } from '../components/tweet/Timeline';
 import { ForkMe } from 'fork-me-corner';
-import { Flex } from '@chakra-ui/react';
+import { Box, Flex } from '@chakra-ui/react';
 import { bgPalette } from '../components/ColorPalette';
 
 interface Props {
@@ -18,7 +18,9 @@ const query = '-RT cc @sseraphini -from:sseraphini_bot';
 const HomePage: NextPage<Props> = (props: Props) => {
   return (
     <div>
-      <ForkMe repo="https://github.com/sibelius/ccsseraphini" />
+      <Box position="absolute" zIndex="2" top="0" right="0">
+        <ForkMe repo="https://github.com/sibelius/ccsseraphini" />
+      </Box>
       <Flex
         direction={{ base: 'column', lg: 'row' }}
         gap="12px"


### PR DESCRIPTION
I was writing an issue about this, and by explaining the problem it really helped me figure out how to solve it 😂

![image](https://user-images.githubusercontent.com/42651514/161406375-10a4219d-2ab3-444e-b4f8-1e55ad10b3f6.png)

The problem was with z-index, but since the button is made by a lib I couldn't change the z-index of it.
So the solution was the most obvious you can think, I just wrapped it inside a div with z-index being above 1 and with the same properties of the `<a>` tag made by the lib (absolute, top: 0 and right: 0)