### PR TITLE
improve sentry setup removing unnecessary .env and fix page 500

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -16,6 +16,3 @@ CRONJOB_HEADER_VALUE=# add a value here, should be same as in cronjob.org , samp
 ## Sentry - logging and debugging in production
 SENTRY_DSN=
 NEXT_PUBLIC_SENTRY_DSN=
-SENTRY_ORG=
-SENTRY_PROJECT=
-SENTRY_AUTH_TOKEN=

--- a/apps/web/sentry.properties
+++ b/apps/web/sentry.properties
@@ -1,7 +1,0 @@
-# we can ignore it for now
-defaults.url=https://sentry.io/
-defaults.org=
-defaults.project=
-# cli.executable=../path/to/bin/sentry-cli
-# locally cli.executable=../../../../.npm/_npx/79376/lib/node_modules/@sentry/wizard/node_modules/@sentry/cli/bin/sentry-cli
-cli.executable=../../node_modules/@sentry/cli/bin/sentry-cli

--- a/apps/web/src/pages/_error.js
+++ b/apps/web/src/pages/_error.js
@@ -1,4 +1,5 @@
 import NextErrorComponent from 'next/error';
+import { Error } from 'components/Error';
 
 import * as Sentry from '@sentry/nextjs';
 
@@ -11,7 +12,12 @@ const CustomErrorPage = ({ statusCode, hasGetInitialPropsRun, err }) => {
     // Flushing is not required in this case as it only happens on the client
   }
 
-  return <NextErrorComponent statusCode={statusCode} />;
+  return (
+    <Error
+      errorCode={statusCode}
+      message={err?.message || 'Ops! Internal error 🙉'}
+    />
+  );
 };
 
 CustomErrorPage.getInitialProps = async ({ res, err, asPath }) => {


### PR DESCRIPTION
we only need DSN from sentry, removed sentry.properties, and fix the error page 500, should display the custom Error component instead of the default one from nextjs