### PR TITLE
fix: tweet id on retweet

### DIFF
--- a/apps/sseramemes/src/tweetMeme.ts
+++ b/apps/sseramemes/src/tweetMeme.ts
@@ -47,7 +47,7 @@ export const addWatermark = async (buffer: Buffer): Promise<Buffer> => {
 const scheduleRetweet = (tweet: TweetV1) => {
   setTimeout(async () => {
     try {
-      await client.v1.post(`statuses/retweet/${tweet.id}.json`);
+      await client.v1.post(`statuses/retweet/${tweet.id_str}.json`);
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Twitter retweet API uses `id_str` instead of the `id` property from the tweet object.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
