### PR TITLE
refactor(sseramemes): Implemented conditionsToBeAMeme options to avoid stacking if/using switch cases

### DIFF
--- a/apps/sseramemes/src/handleMemeVoting.ts
+++ b/apps/sseramemes/src/handleMemeVoting.ts
@@ -37,15 +37,12 @@ export const isMeme = async (
     message = msg;
   }
 
-  if (!isMessageFromChannelMemes(message)) {
-    return false;
-  }
-
-  if (message.attachments.size !== 1) {
-    return false;
-  }
-
-  return true;
+  const conditionsToBeAMeme = [
+    isMessageFromChannelMemes(message),
+    message.attachments.size == 1
+  ]
+  
+  return !conditionsToBeAMeme.includes(false)
 };
 
 /**

--- a/apps/sseramemes/tsconfig.json
+++ b/apps/sseramemes/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es6",
     "module": "commonjs",
-    "lib": ["es6", "es2015", "dom"],
+    "lib": ["es6", "es2015", "es2020", "dom"],
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
   }


### PR DESCRIPTION
## Implementations

- Updated `tsconfig.json` lib support to include `es2020` as target platform EcmaScript
- Implemented conditionsToBeAMeme options to avoid stacking if/using switch cases (a condition array that will be checked by the return operator to decide the validity of the meme

```js
const conditionsToBeAMeme = [
    isMessageFromChannelMemes(message),
    message.attachments.size == 1
]
  
return !conditionsToBeAMeme.includes(false)
```