### PR TITLE
FIX usernames do discord

### DIFF
--- a/apps/sseramemes/src/tweetMeme.ts
+++ b/apps/sseramemes/src/tweetMeme.ts
@@ -60,6 +60,9 @@ export const tweetMeme = async (message: Message | PartialMessage) => {
   const mediaId = await uploadMeme(message);
 
   const mediaIds = mediaId ? [mediaId] : undefined;
+  
+  message.content=message.content.replace(/@\\/g,'');
+  message.content=message.content.replace(/#[\d]{1,}/g,'');
 
   const tweet = await client.v1.tweet(message.content, {
     media_ids: mediaIds,


### PR DESCRIPTION
# Summary

o [jacarelho](https://github.com/jeffque) encontrou um bug no tratamento dos usernames do discord

precisa tratar o texto antes de tweetar senão precisa escapar manualmente com [acento grave](https://pt.wikipedia.org/wiki/Acento_grave) cada username do twitter digitado no discord (ex: \`@hackerguacho\`) pra evitar que o discord adicione o #id no final da mensagem e uma barra \\ após o arroba (ex. @\\hackergaucho#1234)

nessa solução resolvi isso eliminando a barra do @\\ e depois eliminando o sufixo #id com regex

## Test Plan

não executei testes, apenas alterei o código seguindo o relato do jacarelho.