### PR TITLE
feat: added monthly, biweekly and weekly ranking

### DIFF
--- a/apps/bot/src/config.ts
+++ b/apps/bot/src/config.ts
@@ -35,6 +35,6 @@ export const config = {
 
   PORT: 3000,
 
-  TWEET_RANKING_RULE: process.env.TWEET_RANKING_RULE || '19:00',
-  SYNC_TWEETS_RULE: process.env.SYNC_TWEETS_RULE || '20:13',
+  TWEET_RANKING_RULE: process.env.TWEET_RANKING_RULE || '10:00',
+  SYNC_TWEETS_RULE: process.env.SYNC_TWEETS_RULE || '01:00',
 } as const;

--- a/apps/bot/src/tweetRanking/__tests__/tweetRanking.test.ts
+++ b/apps/bot/src/tweetRanking/__tests__/tweetRanking.test.ts
@@ -56,10 +56,11 @@ it('should run without errors the tweetRanking execute function', async () => {
   //mock console error spy to check if there are errors
   const consoleSpy = jest
     .spyOn(console, 'error')
-    .mockImplementation(() => console.error);
+    .mockImplementation(console.error);
 
   //Get execute function
-  const execute = tweetRanking(created_at);
+  const until = new Date('2021-11-16T19:08:00.000Z');
+  const execute = tweetRanking(created_at, until);
 
   //Execute the ranking creation
   await execute(new Date());

--- a/apps/bot/src/tweetRanking/index.ts
+++ b/apps/bot/src/tweetRanking/index.ts
@@ -3,12 +3,11 @@ import { JobCallback } from 'node-schedule';
 import getRankedTweets from './getRankedTweets';
 import saveRankedTweets from './saveRankedTweets';
 import deleteTemporaryTweets from './deleteTemporaryTweets';
-import createPostFromRankedTweets from './createPostFromRankedTweets';
+import postTweetRanking from './postTweetRanking';
 
-const tweetRanking = (since: Date) => {
+const tweetRanking = (since: Date, until: Date = new Date()) => {
   const execute: JobCallback = async () => {
     try {
-      const until = new Date();
       const rankedTweets = await getRankedTweets(since);
       if (!rankedTweets?.length) {
         console.info('Unable to calculate tweet ranking');
@@ -22,17 +21,18 @@ const tweetRanking = (since: Date) => {
         console.error('Fail to save ranked tweets', error);
         console.info("Temporary tweets wasn't deleted");
       }
-
-      await createPostFromRankedTweets(since, until);
     } catch (error) {
       console.error('Fail to calculate tweet ranking', error);
+    }
+
+    try {
+      await postTweetRanking(until);
+    } catch (error) {
+      console.error('Fail to handle ranking', error);
     }
   };
 
   return execute;
 };
-
-export const dailyTweetRanking = () =>
-  tweetRanking(new Date(Date.now() - 86400000));
 
 export default tweetRanking;

--- a/apps/bot/src/tweetRanking/jobs/rankingJob.ts
+++ b/apps/bot/src/tweetRanking/jobs/rankingJob.ts
@@ -1,14 +1,17 @@
-import { scheduleJob } from 'node-schedule';
+import { JobCallback, scheduleJob } from 'node-schedule';
 
-import { dailyTweetRanking } from '..';
+import tweetRanking from '..';
 import getRuleFromConfig from './getRuleFromConfig';
 
 const rankingJob = () => {
   const rule = getRuleFromConfig('TWEET_RANKING_RULE');
   if (!rule) return;
 
-  scheduleJob(rule, dailyTweetRanking());
-  console.info('Ranking job started, with the rule: ', rule);
+  const since = new Date(Date.now() - 86400000);
+  const executeTweetRanking: JobCallback = tweetRanking(since);
+
+  scheduleJob(rule, executeTweetRanking);
+  console.info('Ranking Job started, with the rule: ', rule);
 };
 
 export default rankingJob;

--- a/apps/bot/src/tweetRanking/postTweetRanking.ts
+++ b/apps/bot/src/tweetRanking/postTweetRanking.ts
@@ -1,0 +1,54 @@
+import createPostFromRankedTweets from './createPostFromRankedTweets';
+
+const isSunday = (date: Date): boolean => date.getDay() === 0;
+const getFirstDateOfMonth = (date: Date): Date =>
+  new Date(date.getFullYear(), date.getMonth(), 1);
+const getLastDayOfMonth = (month: number, year: number): number =>
+  new Date(year, month, 0).getDate();
+const getYesterday = (date: Date): Date => {
+  const newDate: Date = new Date(date.setHours(23, 59, 59, 999));
+  return new Date(newDate.valueOf() - 1000 * 60 * 60 * 24);
+};
+const getSinceResolverByDate = (date: Date): Record<number, Function> => {
+  const lastDay = getLastDayOfMonth(date.getMonth(), date.getFullYear());
+  const lastBiweeklyDay = lastDay - 1;
+  const firstBiweeklyDay = Math.floor(lastBiweeklyDay / 2);
+  const sinceByDateMap: Record<number, Function> = {
+    [lastDay]: (date: Date): Date => getFirstDateOfMonth(date),
+    [firstBiweeklyDay]: (date: Date) => getFirstDateOfMonth(date),
+    [lastBiweeklyDay]: (date: Date) =>
+      new Date(date.getFullYear(), date.getMonth(), firstBiweeklyDay + 1),
+  };
+
+  return sinceByDateMap;
+};
+
+const postTweetRanking = async (date: Date): Promise<void> => {
+  const yesterday: Date = getYesterday(date);
+  const sinceByDateMap: Record<number, Function> =
+    getSinceResolverByDate(yesterday);
+  const yesterdayDate: number = yesterday.getDate();
+  const getSince: Function = sinceByDateMap[yesterdayDate];
+
+  //Monthly or biweekly ranking
+  if (!!getSince) {
+    const since = getSince(yesterday);
+    await createPostFromRankedTweets(since, yesterday);
+    return;
+  }
+
+  //Weekly ranking
+  if (isSunday(yesterday)) {
+    const lastMonday: Date = new Date(
+      yesterday.valueOf() - 1000 * 60 * 60 * 24 * 6,
+    );
+    await createPostFromRankedTweets(lastMonday, yesterday);
+    return;
+  }
+
+  //Daily ranking
+  const yesterdayMidnight: Date = new Date(yesterday.setHours(0, 0, 0, 0));
+  await createPostFromRankedTweets(yesterdayMidnight, yesterday);
+};
+
+export default postTweetRanking;


### PR DESCRIPTION
- Now the ranking runs in D-1, so, today will show the ranking for yesterday
- Added Monthly, biweekly and weekly rankings.  
- Now we have a priority system to publish rankings, therefore, only one ranking can be created in a day. These are our priority right now:  Monthly > Biweekly > Weekly > Daily. 