### PR TITLE
Feat water mark on videos

### DIFF
--- a/apps/sseramemes/.gitignore
+++ b/apps/sseramemes/.gitignore
@@ -1,1 +1,4 @@
 test.png
+raw.mp4
+test-video.mp4
+*.js

--- a/apps/sseramemes/.gitignore
+++ b/apps/sseramemes/.gitignore
@@ -1,4 +1,3 @@
 test.png
 raw.mp4
 test-video.mp4
-*.js

--- a/apps/sseramemes/package.json
+++ b/apps/sseramemes/package.json
@@ -9,6 +9,7 @@
     "server:start": "pm2 start ecosystem.config.js",
     "start": "esrun src/index.ts",
     "test": "jest",
+    "test:addLogoVideo": "esrun scripts/testAddLogoToVideo.ts",
     "test:addlogo": "esrun scripts/testAddLogo.ts",
     "test:resize": "esrun scripts/testResizeImage.ts"
   },
@@ -17,6 +18,7 @@
     "@jimp/types": "0.16.1",
     "discord.js": "14.6.0",
     "dotenv": "16.0.2",
+    "ffmpeg": "0.0.4",
     "jimp": "0.16.1",
     "node-fetch": "3.2.10",
     "twitter-api-sdk": "1.1.0",

--- a/apps/sseramemes/scripts/testAddLogoToVideo.ts
+++ b/apps/sseramemes/scripts/testAddLogoToVideo.ts
@@ -1,0 +1,17 @@
+import * as fs from 'fs';
+import { addLogoToVideo } from '../src/image-scripts/addLogoToVideo';
+/**
+ * For testing, please do have a video file in the root of the project named raw.mp4
+ */
+const testAddLogoToVideo = async () => {
+  const video = await fs.promises.readFile('raw.mp4');
+
+  const bufferWithWatermark = await addLogoToVideo(video);
+
+  /**
+   * Save bufferWithWatermark to file.
+   */
+  await fs.promises.writeFile('test-video.mp4', bufferWithWatermark);
+};
+
+testAddLogoToVideo().then();

--- a/apps/sseramemes/src/image-scripts/addLogoToVideo.ts
+++ b/apps/sseramemes/src/image-scripts/addLogoToVideo.ts
@@ -1,0 +1,35 @@
+import fs from 'fs';
+import ffmpeg from 'ffmpeg';
+import path from 'path';
+import Jimp from 'jimp';
+
+export const addLogoToVideo = async (video: Buffer): Promise<Buffer> => {
+  // save buffer in a temp file
+  await fs.promises.writeFile('temp.mp4', video);
+  const videoEditor = await new ffmpeg('temp.mp4');
+
+  const logo = await Jimp.read(path.join(process.cwd(), './static/logo.png'));
+  logo.resize(40, 40);
+  const logoBuffer = await logo.getBufferAsync(logo.getMIME());
+  await fs.promises.writeFile('temp-logo.png', logoBuffer);
+
+  try {
+    await videoEditor.fnAddWatermark(
+      path.join(process.cwd(), './temp-logo.png'),
+      'temp-video-with-logo.mp4',
+      { position: 'SW' },
+    );
+
+    const videoWithLogo = await fs.promises.readFile(
+      'temp-video-with-logo.mp4',
+    );
+    // remove files
+    await fs.promises.unlink('temp.mp4');
+    await fs.promises.unlink('temp-logo.png');
+    await fs.promises.unlink('temp-video-with-logo.mp4');
+
+    return videoWithLogo;
+  } catch (e) {
+    console.log(e);
+  }
+};

--- a/apps/sseramemes/src/tweetMeme.ts
+++ b/apps/sseramemes/src/tweetMeme.ts
@@ -4,6 +4,7 @@ import fetch from 'node-fetch';
 import { RETWEET_MEME_TIMEOUT } from './score';
 import { addLogoToImage } from './image-scripts';
 import { getMessageContent } from './getMessageContent';
+import { addLogoToVideo } from './image-scripts/addLogoToVideo';
 
 const client = new TwitterApi({
   appKey: process.env.TWITTER_API_KEY,
@@ -16,6 +17,12 @@ export const ALLOWED_MEME_TYPES_TO_ADD_LOGO = [
   'image/jpg',
   'image/jpeg',
   'image/png',
+];
+
+export const ALLOWED_MEME_TYPES_TO_ADD_VIDEO_LOGO = [
+  'video/mp4',
+  'video/quicktime',
+  'video/avi',
 ];
 
 export const uploadMeme = async (message: Message | PartialMessage) => {
@@ -34,6 +41,10 @@ export const uploadMeme = async (message: Message | PartialMessage) => {
    */
   if (ALLOWED_MEME_TYPES_TO_ADD_LOGO.includes(mimeType)) {
     newBuffer = await addLogoToImage(buffer);
+  }
+
+  if (ALLOWED_MEME_TYPES_TO_ADD_VIDEO_LOGO.includes(mimeType)) {
+    newBuffer = await addLogoToVideo(buffer);
   }
 
   try {


### PR DESCRIPTION
This pr focus on adding water mark to videos
note that to make this happen, I need to create temp files to make it work in our current workflow.
using an M2 MacBook, it normally took ~2 sec to run thought a 28-sec video and add a water mark to it. We will need more tests, if perf becomes an issue, maybe we will need to adjust some of the workflow