### PR TITLE
fix: add temp to final.mp4 to do not restart pm2

### DIFF
--- a/apps/sseramemes/src/image-scripts/addLogoToVideo.ts
+++ b/apps/sseramemes/src/image-scripts/addLogoToVideo.ts
@@ -31,14 +31,14 @@ export const addLogoToVideo = async (
       'temp-video-with-logo.mp4',
       { position: 'SW' },
     );
-    await removeAudioFromVideo('temp-video-with-logo.mp4', 'final.mp4');
-    const videoWithLogo = await fs.promises.readFile('final.mp4');
+    await removeAudioFromVideo('temp-video-with-logo.mp4', 'temp-final.mp4');
+    const videoWithLogo = await fs.promises.readFile('temp-final.mp4');
 
     // remove files
     await fs.promises.unlink(tempFilePath);
     await fs.promises.unlink('temp-logo.png');
     await fs.promises.unlink('temp-video-with-logo.mp4');
-    await fs.promises.unlink('final.mp4');
+    await fs.promises.unlink('temp-final.mp4');
 
     return videoWithLogo;
   } catch (e) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

`final.mp4` restarts PM2