### PR TITLE
docs: fix .env discord meme channel var key on readme

### DIFF
--- a/apps/sseramemes/README.md
+++ b/apps/sseramemes/README.md
@@ -9,7 +9,7 @@
 
 1. Add token to `.env` file with name `DISCORD_TOKEN`.
 
-1. Get memes channel id from Discord and add it to `.env` file with name `DISCORD_CHANNEL_ID`.
+1. Get memes channel id from Discord and add it to `.env` file with name `DISCORD_MEMES_CHANNEL_ID`.
 
 1. Go to Twitter developer portal and retrieve the tokens and save them to `.env`:
    - `TWITTER_ACCESS_TOKEN`


### PR DESCRIPTION
Fix the typo on README. The .env.example was already ok.